### PR TITLE
Run libraries though babel

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -22,6 +22,7 @@ module.exports = Merge.smart(commonConfig, {
       {
         test: /\.(js|jsx)$/,
         include: [
+          path.resolve(__dirname, '../node_modules'),
           path.resolve(__dirname, '../src'),
         ],
         loader: 'babel-loader',


### PR DESCRIPTION
Libraries were not run through babel and thus the bundles failed the es5 check.