### PR TITLE
Disallow eslint warnings for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 script:
 - make validate-no-uncommitted-package-lock-changes
 - npm run i18n_extract
-- npm run lint
+- npm run lint -- --max-warnings 0
 - npm run test
 - npm run build
 - npm run is-es5


### PR DESCRIPTION
Travis builds will currently fail if `npm run lint` returns any errors.

This change will make them also fail if `npm run lint` returns any warnings.

This is based on my observation that messages that do not block merging will often go ignored, eventually leading to a situation where they are too noisy to be useful and too overwhelming to fix. For example, pylint warnings in edx-platform were ignored for a 2-ish year time period, during which the warning count grew to ~2,500.