### PR TITLE
Disable pre-commit linting by default?

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "start": "fedx-scripts webpack-dev-server --progress",
     "test": "fedx-scripts jest --coverage --passWithNoTests"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint"
-    }
-  },
+  //// In order to enable pre-commit linting, uncomment the "husky" dictionary
+  //// and run 'npm install'.
+  // "husky": {
+  //   "hooks": {
+  //     "pre-commit": "npm run lint"
+  //   }
+  // },
   "author": "edX",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/edx/frontend-template-application#readme",


### PR DESCRIPTION
(This is completely opinion-based :)

I like to `git commit` and `git commit --amend` a lot, and I tend to run `npm run lint` anyway as part of my development process. This makes these pre-commit hooks more of a slow-down than anything else for me. So, here's a PR which would leave `husky` installed, but disable it by default.

However, it's not hard for me to bypass these hooks for myself locally. So if others find them useful, I am happy to close this PR, and go on running `git commit --no-verify -m ...`!