### PR TITLE
Update jest.config.js to use setupFilesAfterEnv

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,9 @@
 const { createConfig } = require('@edx/frontend-build');
 
 module.exports = createConfig('jest', {
-  setupFiles: [
+  // setupFilesAfterEnv is used after the jest environment has been loaded.  In general this is what you want.  
+  // If you want to add config BEFORE jest loads, use setupFiles instead.  
+  setupFilesAfterEnv: [
     '<rootDir>/src/setupTest.js',
   ],
   coveragePathIgnorePatterns: [


### PR DESCRIPTION
This was a change I've had to make in multiple MFEs to be able to use @testing-library/jest-dom and its extend-expect functionality, which adds a bunch of new DOM assertions to expectations.  Very useful.  From reading around a bit, it seems like setupFilesAfterEnv is more generally what we'd want to use, so I'm hoping this will save someone else the Google search I've now done multiple times.