### PR TITLE
chore: add fix flag for linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "is-es5": "es-check es5 ./dist/*.js",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
+    "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx .",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "test": "fedx-scripts jest --coverage --passWithNoTests"


### PR DESCRIPTION
If you too forget what language you're working in and thus miss adding 800 semi-colons, this new command is for you!

While I've never had issues with the fix flag, I imagine there could be cases where we don't agree with its changes and thus may want the option to run without it, which is why I leave the original lint wherever I go (also because that command isn't going to work on CI)
