### PR TITLE
docs: Add template README for MFEs

### DIFF
--- a/README-template-frontend-app.rst
+++ b/README-template-frontend-app.rst
@@ -1,0 +1,77 @@
+|Build Status| |Codecov| |npm_version| |npm_downloads| |license| |semantic-release| ## As many of these as you'd like to include, or others if you wish!
+
+frontend-app-[YOUR NAME HERE]
+==============================
+
+Please tag **@edx/[YOUR-TEAM]** on any PRs or issues.  Thanks!
+
+Introduction
+------------
+
+*What is this MFE? Add a 2-3 sentence description of what it is and what it does.*
+
+*What is the _domain_ of this MFE? That is, what is in here, what belongs here? What's*
+*_not_ in here that people might think could belong here, but is purposefully excluded?*
+
+*Add any additional detail/notes relevant to understanding the whats/whys of this*
+*MFE: could be links to publically available wikis/documents.*
+
+Devstack Installation
+---------------------
+
+Follow these steps to provision, run, and enable an instance of the [YOUR NAME HERE] MFE for local development via the
+`official Open edX devstack
+<https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/installation/index.html>`_.
+
+1. Enumerated list of steps & code blocks, like this:
+
+   .. code-block::
+
+      mkdir -p ~/workspace/
+      cd ~/workspace/
+      git clone https://github.com/edx/devstack.git
+
+2. Include as many screenshots as you can, to make your guide easier to follow! Include images with the following syntax:
+
+
+   .. image:: ./docs/images/example_image.png
+
+Environment Variables/Setup Notes
+---------------------------------
+
+*Does this MFE rely on other MFEs, or LMS/Studio? Does it require use of specific APIs? Do certain settings*
+*need to be enabled?*
+
+Any Other Relevant Sections
+---------------------------
+
+*This is optional, but you might have additional sections you wish to cover such as i18n notes, build process*
+*notes, stuff about ADRs, stuff about architecture, or more.*
+
+Known Issues
+------------
+
+* A bulleted list of issues, ideally with JIRA ticket numbers attached
+
+* OR - a link to a publically available wiki/document
+
+Development Roadmap
+-------------------
+
+The following is a list of current short-term development targets, in (rough) descending order of priority:
+
+* A bulleted list of roadmap items, ideally with JIRA ticket numbers attached (but could just be
+  a high-level overview of upcoming features/epics)
+
+* OR - a link to a publically available wiki/document
+
+
+==============================
+
+References (for authors of the README; delete this section before publishing)
+
+* https://github.com/edx/frontend-app-library-authoring/blob/master/README.rst has many of the above discussed
+  sections and implements them well
+
+* https://opencraft.com/blog/introducing-open-edx-publisher/#how-does-it-work is an example of explaining when
+  env variables/settings are required

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,12 @@ In the following steps, replace "frontend-template-application' with the name of
 
 The dev server is running at `http://localhost:8080 <http://localhost:8080>`_ or whatever port you setup.
 
+Making Your New Project's README File
+-------------------------------------
+
+Move the file ``README-template-frontend-app.rst`` to your project's ``README.rst`` file. Please fill out all
+the sections - this helps out all developers understand your MFE, how to install it, and how to use it.
+
 Project Structure
 -----------------
 


### PR DESCRIPTION
Add a template README for new MFEs to use.

Purpose: Help internal & external devs self serve by understanding the whats and whys of your MFE

https://openedx.atlassian.net/browse/TNL-8081